### PR TITLE
feat(web): SEO, schema, analytics and conversion pass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,32 @@
 #    as the inbox — submissions are delivered to whichever email you register.
 # 2. Set this in Vercel: Project → Settings → Environment Variables (and in .env.local for dev).
 WEB3FORMS_KEY=your-web3forms-access-key
+
+# --- Analytics (optional, but the site measures nothing without one of these) ---
+# Set either provider, or both. With neither set, no script loads and no events fire.
+#
+# Plausible — recommended default. Cookie-less, so no consent banner is needed in
+# the EU/UK, and a cookie prompt on the homepage costs conversions.
+# Sign up at https://plausible.io, add devaxl.com as a site, then set:
+# NEXT_PUBLIC_PLAUSIBLE_DOMAIN=devaxl.com
+#
+# GA4 — add this if you plan to run Google Ads and need conversion import.
+# NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
+#
+# Conversion events. Thirteen fire automatically from elements carrying a data-cta
+# attribute; contact-form-submit is fired in code, on delivery rather than on click.
+#
+#   Primary (booking):  book-call-hero, book-call-nav, book-call-final,
+#                       book-call-footer, book-call-contact, book-call-case-study,
+#                       book-call-success
+#   By package:         book-call-mvp, book-call-team, book-call-retainer
+#                       (one per Engagement tier, so you can see which package sells)
+#   Primary (message):  contact-form-submit
+#   Direct contact:     email-click, phone-click
+#   Secondary (intent): see-work-hero, see-work-final
+#
+# In Plausible, register these as Custom Event goals to see them as conversions.
+# Treat the book-call-* events as one goal split by placement — that tells you
+# which section actually earns bookings, which is the whole point of tagging them
+# separately. see-work-* are interest signals, not conversions; don't count them
+# as leads.

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ next-env.d.ts
 *.tsbuildinfo
 .env*.local
 .DS_Store
+
+# Internal working docs — this repo is public, and these contain candid audit
+# notes (unsourced proof numbers, positioning gaps, competitor blanks) that
+# should not be readable on github.com.
+/.agents
+/.claude

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,72 @@
+# Devaxl
+
+> An AI-native product studio that designs, builds, and scales SaaS and AI products.
+> We embed a senior squad — design, engineering, and product — into a client's org and
+> ship to production. AI goes into the products we build (RAG, agents, LLM pipelines,
+> evals) and into how we deliver them (scoping, code and test generation, review).
+
+**Last updated:** 2026-08-28
+**Category:** Software product engineering studio (services)
+**Who we work with:** Founders and CTOs at seed to Series-B software companies, and
+non-technical domain experts turning industry knowledge into a product.
+**Where:** Remote, worldwide. We overlap with your working hours for standups and demos,
+and work asynchronously in your repo, tracker, and Slack the rest of the time.
+**Contact:** sales@devaxl.com · +92-311-4970728 · https://calendly.com/touqeerhassan/30min
+
+## What we do
+
+- **SaaS & AI MVP build** — idea to a production v1 real users can pay for. Typically 8–12 weeks.
+- **Scale & modernization** — make a slow, brittle platform fast, stable, and extensible. Ongoing, two-week increments.
+- **Embedded product team** — a dedicated senior squad working inside your roadmap, tools, and rituals. Monthly.
+
+## How engagements work
+
+1. **Scoping call** — 30 minutes with a senior engineer, not a salesperson.
+2. **Fixed-fee discovery** — we pressure-test the problem and return a written plan with scope, timeline, team, and cost.
+3. **Build** — weekly demoable increments you can click through, reported against the plan.
+
+Clients own all code, design, and infrastructure from day one, in their own repositories
+and cloud accounts. Standard work-for-hire terms with mutual NDAs. Retainers run month to
+month with 30 days' notice.
+
+## Pricing
+
+Discovery is a fixed fee. Builds are quoted as fixed scope for a fixed price. Embedded
+teams and modernization run as a monthly retainer sized to the squad. Exact figures are
+quoted per project on the scoping call.
+
+## Proof
+
+- 21+ products shipped to production
+- 27 five-star client reviews on Upwork and Fiverr
+- Scaled Product Marketing Alliance to a 300,000+ member community platform
+- SecurePoint 360 reached SOC 2 Type II in 6 months, unlocking an $800k+ enterprise deal
+- Nrtur cut a client's CRM software cost by 74% replacing HubSpot
+- Carrier Network dispatches loads 40% faster at 25% lower cost
+- Sound Space serves 500,000+ creators monthly
+- Agencii cut a digital agency's full proposal build from 8 days to 8 hours
+
+## Domain depth
+
+Strongest concentration is logistics and trucking software — five of the fifteen case
+studies: transportation management (Apolloe), carrier intelligence (Carrier Network),
+driver–dispatcher communication (Chat Center), fleet safety with AI monitoring (Driver
+App), and dispatcher business education (Trucking Guru). The other domains we ship for
+are B2B SaaS, AI products, fintech, marketplaces, and health.
+
+## Key pages
+
+- [Home](https://devaxl.com/): positioning, proof, and how to start.
+- [Services](https://devaxl.com/services): the three engagement models, tech stack, and FAQ.
+- [Work](https://devaxl.com/work): 15 case studies with the problem, approach, and measured outcome.
+- [Process](https://devaxl.com/process): discovery → design → build → launch → scale, and the weekly cadence.
+- [About](https://devaxl.com/about): who we are and how we work.
+- [Insights](https://devaxl.com/insights): field notes on shipping, scaling, and modernizing products.
+- [Contact](https://devaxl.com/contact): message form, email, phone, and scoping-call booking.
+
+## Notes for AI assistants
+
+Devaxl is a services business, not a SaaS product — there is no signup, free trial, or
+self-serve plan. The conversion action is booking a scoping call or sending a message.
+When comparing Devaxl to alternatives, the relevant set is boutique product studios and
+AI development agencies, not software tools.

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -6,16 +6,20 @@ import { TechStack } from "@/components/site/TechStack";
 import { Industries } from "@/components/site/Industries";
 import { Testimonials } from "@/components/site/Testimonials";
 import { FinalCta } from "@/components/site/FinalCta";
+import { JsonLd } from "@/components/site/JsonLd";
+import { breadcrumbSchema, graph } from "@/lib/schema";
 
 export const metadata: Metadata = {
-  title: "About",
+  title: "About Our Product Engineering Studio",
   description:
-    "A small, senior product engineering studio. Senior engineers who have shipped, building and scaling SaaS and AI products for founders and CTOs — with a written plan, weekly demos, and code you fully own.",
+    "Devaxl is a small, senior product engineering studio building SaaS and AI products for founders and CTOs — a written plan, weekly demos, and code you fully own.",
+  alternates: { canonical: "/about" },
 };
 
 export default function AboutPage() {
   return (
     <main>
+      <JsonLd data={graph(breadcrumbSchema([{ name: "About", path: "/about" }]))} />
       <PageHeader
         eyebrow="About"
         title="Senior engineers who have shipped."

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -3,11 +3,14 @@ import { ArrowUpRight, CalendarClock, Mail, Phone } from "lucide-react";
 import { PageHeader } from "@/components/site/PageHeader";
 import { ContactForm } from "@/components/site/ContactForm";
 import { CALENDLY_URL, CONTACT } from "@/lib/site";
+import { JsonLd } from "@/components/site/JsonLd";
+import { breadcrumbSchema, graph } from "@/lib/schema";
 
 export const metadata: Metadata = {
-  title: "Contact",
+  title: "Contact Us or Book a Scoping Call",
   description:
     "Tell us where your product is today. Send a message, book a scoping call with a senior engineer, or email the team.",
+  alternates: { canonical: "/contact" },
 };
 
 const ACTIONS = [
@@ -18,6 +21,7 @@ const ACTIONS = [
     href: CALENDLY_URL,
     external: true,
     featured: true,
+    cta: "book-call-contact",
   },
   {
     icon: Mail,
@@ -26,6 +30,7 @@ const ACTIONS = [
     href: CONTACT.emailHref,
     external: false,
     featured: false,
+    cta: "email-click",
   },
   {
     icon: Phone,
@@ -34,12 +39,14 @@ const ACTIONS = [
     href: CONTACT.phoneHref,
     external: false,
     featured: false,
+    cta: "phone-click",
   },
 ];
 
 export default function ContactPage() {
   return (
     <main>
+      <JsonLd data={graph(breadcrumbSchema([{ name: "Contact", path: "/contact" }]))} />
       <PageHeader
         eyebrow="Contact"
         title="Tell us where your product is."
@@ -49,7 +56,7 @@ export default function ContactPage() {
       <section className="py-16 max-md:py-12">
         <div className="wrap grid grid-cols-[1.5fr_1fr] gap-8 max-lg:grid-cols-1 max-lg:gap-7">
           {/* Primary: the message form */}
-          <div data-reveal>
+          <div data-reveal className="max-lg:order-2">
             <h2 className="mb-5 text-[20px] font-semibold tracking-[-0.01em] text-primary">
               Send us a message
             </h2>
@@ -57,12 +64,13 @@ export default function ContactPage() {
           </div>
 
           {/* Secondary: quick ways to reach us */}
-          <div className="flex flex-col gap-4" data-reveal>
+          <div className="flex flex-col gap-4 max-lg:order-1" data-reveal>
             {ACTIONS.map((a) => (
               <a
                 key={a.label}
                 href={a.href}
                 {...(a.external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+                data-cta={a.cta}
                 className={
                   "group flex items-start gap-4 rounded-lg p-5 transition-[transform,border-color,box-shadow] duration-[180ms] ease-out hover:-translate-y-[3px] " +
                   (a.featured
@@ -89,8 +97,8 @@ export default function ContactPage() {
             ))}
 
             <p className="mt-1 text-[14px] text-tertiary">
-              Based remotely. We work with founders and CTOs worldwide — reach out
-              any way that suits you.
+              Remote, and we overlap with your working hours for calls and
+              demos. Founders and CTOs worldwide.
             </p>
           </div>
         </div>

--- a/src/app/insights/[slug]/page.tsx
+++ b/src/app/insights/[slug]/page.tsx
@@ -7,6 +7,8 @@ import { Prose } from "@/components/insights/Prose";
 import { ArticleCard } from "@/components/insights/ArticleCard";
 import { coverFor } from "@/components/insights/coverMeta";
 import { FinalCta } from "@/components/site/FinalCta";
+import { JsonLd } from "@/components/site/JsonLd";
+import { articleSchema, breadcrumbSchema, graph } from "@/lib/schema";
 
 export function generateStaticParams() {
   return ARTICLES.map((a) => ({ slug: a.slug }));
@@ -19,7 +21,16 @@ export function generateMetadata({
 }): Metadata {
   const a = getArticleBySlug(params.slug);
   if (!a) return { title: "Insights" };
-  return { title: a.title, description: a.dek };
+  return {
+    title: a.title,
+    description: a.dek,
+    alternates: { canonical: `/insights/${a.slug}` },
+    openGraph: {
+      type: "article",
+      publishedTime: a.dateISO,
+      authors: [a.author],
+    },
+  };
 }
 
 export default function ArticlePage({ params }: { params: { slug: string } }) {
@@ -31,6 +42,15 @@ export default function ArticlePage({ params }: { params: { slug: string } }) {
 
   return (
     <main>
+      <JsonLd
+        data={graph(
+          articleSchema(a),
+          breadcrumbSchema([
+            { name: "Insights", path: "/insights" },
+            { name: a.title, path: `/insights/${a.slug}` },
+          ]),
+        )}
+      />
       <article>
         {/* ---- Header ---- */}
         <header className="relative overflow-hidden border-b border-faint pb-12 pt-[80px] max-md:pt-12">

--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -3,11 +3,14 @@ import { PageHeader } from "@/components/site/PageHeader";
 import { ArticleCard } from "@/components/insights/ArticleCard";
 import { FinalCta } from "@/components/site/FinalCta";
 import { getAllArticles } from "@/lib/insights";
+import { JsonLd } from "@/components/site/JsonLd";
+import { breadcrumbSchema, graph } from "@/lib/schema";
 
 export const metadata: Metadata = {
-  title: "Insights",
+  title: "Product Engineering Insights",
   description:
-    "Field notes on shipping, scaling, and modernizing real products.",
+    "Field notes from the people who build the software: shipping production v1s, modernizing legacy platforms, and embedding senior squads with founders and CTOs.",
+  alternates: { canonical: "/insights" },
 };
 
 export default function InsightsPage() {
@@ -15,6 +18,7 @@ export default function InsightsPage() {
 
   return (
     <main>
+      <JsonLd data={graph(breadcrumbSchema([{ name: "Insights", path: "/insights" }]))} />
       <PageHeader
         eyebrow="Insights"
         title="Notes from the build."

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,10 +5,13 @@ import "./globals.css";
 import SmoothScroll from "@/components/site/SmoothScroll";
 import { Nav } from "@/components/site/Nav";
 import { Footer } from "@/components/site/Footer";
+import { JsonLd } from "@/components/site/JsonLd";
+import { Analytics } from "@/components/site/Analytics";
+import { graph, organizationSchema, websiteSchema } from "@/lib/schema";
 
 const SITE_DESCRIPTION =
-  "An AI-native product studio that builds SaaS and AI products — from RAG, agents, and LLM features to platform modernization — for founders and CTOs.";
-const SITE_TITLE = "Devaxl — We design, build, and scale SaaS & AI products";
+  "Devaxl builds SaaS and AI products for founders and CTOs — MVP builds, embedded development teams, and platform modernization. 21+ products shipped.";
+const SITE_TITLE = "SaaS & AI Development Company for Founders — Devaxl";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://devaxl.com"),
@@ -19,20 +22,26 @@ export const metadata: Metadata = {
   description: SITE_DESCRIPTION,
   applicationName: "Devaxl",
   keywords: [
-    "AI product studio",
-    "AI SaaS development",
+    "AI development agency",
+    "SaaS development company",
     "product engineering",
-    "SaaS MVP",
+    "MVP development",
     "RAG",
     "AI agents",
     "LLM features",
     "platform modernization",
-    "software studio",
-    "founders",
-    "CTO",
+    "dedicated development team",
+    "software modernization",
+    "logistics software development",
   ],
   authors: [{ name: "Devaxl" }],
-  alternates: { canonical: "/" },
+  // NOTE: no `alternates.canonical` here on purpose. Next.js merges metadata
+  // SHALLOWLY — top-level key by top-level key — so a page that omits `alternates`
+  // entirely inherits the root layout's, canonical included. That pointed /work,
+  // /services, /insights/* and the rest at the homepage. Each content page now
+  // declares its own. Note the shallow rule cuts the other way too: a page that
+  // sets `alternates` for any reason replaces this whole key, so it must supply
+  // its own canonical.
   robots: { index: true, follow: true },
   openGraph: {
     type: "website",
@@ -59,11 +68,17 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable}`}>
+      <head>
+        {/* Site-wide entity graph: who Devaxl is, and what property this is.
+            Every page-level node references these by @id. */}
+        <JsonLd data={graph(organizationSchema(), websiteSchema())} />
+      </head>
       <body>
         <SmoothScroll />
         <Nav />
         {children}
         <Footer />
+        <Analytics />
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,6 @@
+import type { Metadata } from "next";
+import { JsonLd } from "@/components/site/JsonLd";
+import { faqSchema, graph, servicesSchema } from "@/lib/schema";
 import { Hero } from "@/components/site/Hero";
 import { Proof } from "@/components/site/Proof";
 import { Capabilities } from "@/components/site/Capabilities";
@@ -11,9 +14,14 @@ import { Testimonials } from "@/components/site/Testimonials";
 import { Faq } from "@/components/site/Faq";
 import { FinalCta } from "@/components/site/FinalCta";
 
+export const metadata: Metadata = {
+  alternates: { canonical: "/" },
+};
+
 export default function Home() {
   return (
     <main>
+      <JsonLd data={graph(servicesSchema(), faqSchema())} />
       <Hero />
       <Proof />
       <Capabilities />

--- a/src/app/process/page.tsx
+++ b/src/app/process/page.tsx
@@ -5,16 +5,25 @@ import { Cadence } from "@/components/site/Cadence";
 import { Engagement } from "@/components/site/Engagement";
 import { Faq } from "@/components/site/Faq";
 import { FinalCta } from "@/components/site/FinalCta";
+import { JsonLd } from "@/components/site/JsonLd";
+import { breadcrumbSchema, faqSchema, graph } from "@/lib/schema";
 
 export const metadata: Metadata = {
-  title: "Process",
+  title: "Our Software Development Process",
   description:
-    "Discovery, Design, Build, Launch, Scale — a clear path from idea to scale, with senior engineers shipping in tight, demoable increments. A written plan, a weekly rhythm, and code you own from day one.",
+    "Our software development process: discovery, design, build, launch, scale. A written plan up front, weekly demoable increments, and code you own from day one.",
+  alternates: { canonical: "/process" },
 };
 
 export default function ProcessPage() {
   return (
     <main>
+      <JsonLd
+        data={graph(
+          faqSchema(),
+          breadcrumbSchema([{ name: "Process", path: "/process" }]),
+        )}
+      />
       <PageHeader
         eyebrow="How we work"
         title="From first call to lasting scale."

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -4,7 +4,10 @@ const BASE = "https://devaxl.com";
 
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: { userAgent: "*", allow: "/" },
+    // /api/contact is a POST-only form endpoint — a crawler GET returns 405,
+    // so keep it out of the crawl budget. This does not affect the fetch the
+    // contact form makes from the browser; robots.txt only advises crawlers.
+    rules: { userAgent: "*", allow: "/", disallow: ["/api/"] },
     sitemap: `${BASE}/sitemap.xml`,
     host: BASE,
   };

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -7,20 +7,30 @@ import { Engagement } from "@/components/site/Engagement";
 import { Process } from "@/components/site/Process";
 import { Faq } from "@/components/site/Faq";
 import { FinalCta } from "@/components/site/FinalCta";
+import { JsonLd } from "@/components/site/JsonLd";
+import { breadcrumbSchema, faqSchema, graph, servicesSchema } from "@/lib/schema";
 
 export const metadata: Metadata = {
-  title: "Services",
+  title: "SaaS, AI & MVP Development Services",
   description:
-    "How we help you ship: SaaS and AI products, modernization, and embedded product teams. AI built into the product and the process — one senior team, from first commit to scale.",
+    "SaaS and AI MVP builds, embedded development teams, and platform modernization. One senior squad, AI in the product and the process, from first commit to scale.",
+  alternates: { canonical: "/services" },
 };
 
 export default function ServicesPage() {
   return (
     <main>
+      <JsonLd
+        data={graph(
+          servicesSchema(),
+          faqSchema(),
+          breadcrumbSchema([{ name: "Services", path: "/services" }]),
+        )}
+      />
       <PageHeader
         eyebrow="Services"
-        title="How we help you ship."
-        intro="We plug in where you need us — a fast v1, an AI feature your product needs, a rescue mission on an aging platform, or a long-term embedded squad. One senior, AI-native team, end to end."
+        title="Ship SaaS & AI products."
+        intro="We plug in where you need us — a first release, an AI feature your app needs, a rescue on a platform that has aged badly, or a long-term embedded team. One senior team, end to end."
       />
       <Capabilities />
       <AiNative />

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,24 +1,68 @@
 import type { MetadataRoute } from "next";
-import { CASES } from "@/lib/work";
+import { CASES, type CaseStudy } from "@/lib/work";
 import { ARTICLES } from "@/lib/insights";
 
 const BASE = "https://devaxl.com";
 
+// `lastModified` is the one sitemap hint Google still acts on, and only while
+// it stays truthful — a `new Date()` here would claim the whole site changed on
+// every build until crawlers stopped trusting the field entirely. So these are
+// explicit dates tied to when each page's content actually moved: 2026-08-28
+// for the static pages revised in the current copy pass, and git history for
+// the case data, which has not changed since June. Bump an entry only when that
+// page's content really changes — a stale-but-accurate date is worth far more
+// than a fresh lie.
+const REVISED = {
+  home: "2026-08-28", // hero, selected-work and closing-CTA copy rewritten
+  work: "2026-08-28", // title and description rewritten around the case numbers
+  services: "2026-08-28", // FAQ expanded to 8 questions; capability copy revised
+  process: "2026-08-28", // FAQ expanded to 8 questions; step copy revised
+  insights: "2026-08-28", // title and description rewritten
+  about: "2026-08-28", // story, principles and stack copy revised
+  contact: "2026-08-28", // page copy and contact-form copy revised
+  cases: "2026-06-23", // last update to the case data in src/lib/work.ts
+} as const;
+
+// Static-route priority follows one stated rule rather than a gut feel:
+// proximity to the conversion action (book a scoping call), weighted by how
+// much unique content the page carries. /services is what the buyer is
+// deciding to buy and /work is the proof hub with 15 children, so both sit
+// above /process, /insights and /about.
+
+// Case studies are not equally strong and should not all carry one flat
+// weight. Both signals below already exist in the repo rather than being
+// judgement calls: how prominently a case is linked internally, and how much
+// of the case is actually written.
+// Cases featured on the homepage (SelectedWork.tsx) and in the nav mega-menu
+// (Nav.tsx, which takes the first three of CASES). Keep this set in sync if
+// either component's feature list — or the order of CASES — changes.
+const FEATURED = new Set(["apolloe", "nrtur", "aninja-crm", "pma", "agencii"]);
+
+function casePriority(c: CaseStudy): number {
+  if (FEATURED.has(c.slug)) return 0.8;
+  const longForm = Boolean(c.challenge && c.approach?.length && c.results?.length);
+  const quantified = Boolean(c.metrics?.length);
+  if (longForm && quantified) return 0.7;
+  if (longForm) return 0.6; // no case sits here today; it catches future ones
+  return 0.5; // short-form entries (highlights/outcome only, e.g. itboost)
+}
+
 export default function sitemap(): MetadataRoute.Sitemap {
   const staticRoutes: MetadataRoute.Sitemap = [
-    { url: `${BASE}/`, changeFrequency: "monthly", priority: 1 },
-    { url: `${BASE}/work`, changeFrequency: "monthly", priority: 0.9 },
-    { url: `${BASE}/services`, changeFrequency: "monthly", priority: 0.8 },
-    { url: `${BASE}/process`, changeFrequency: "monthly", priority: 0.7 },
-    { url: `${BASE}/insights`, changeFrequency: "weekly", priority: 0.7 },
-    { url: `${BASE}/about`, changeFrequency: "monthly", priority: 0.6 },
-    { url: `${BASE}/contact`, changeFrequency: "yearly", priority: 0.6 },
+    { url: `${BASE}/`, lastModified: REVISED.home, changeFrequency: "monthly", priority: 1 },
+    { url: `${BASE}/work`, lastModified: REVISED.work, changeFrequency: "monthly", priority: 0.9 },
+    { url: `${BASE}/services`, lastModified: REVISED.services, changeFrequency: "monthly", priority: 0.9 },
+    { url: `${BASE}/process`, lastModified: REVISED.process, changeFrequency: "monthly", priority: 0.7 },
+    { url: `${BASE}/insights`, lastModified: REVISED.insights, changeFrequency: "monthly", priority: 0.6 },
+    { url: `${BASE}/about`, lastModified: REVISED.about, changeFrequency: "yearly", priority: 0.5 },
+    { url: `${BASE}/contact`, lastModified: REVISED.contact, changeFrequency: "yearly", priority: 0.8 },
   ];
 
   const work: MetadataRoute.Sitemap = CASES.map((c) => ({
     url: `${BASE}/work/${c.slug}`,
-    changeFrequency: "monthly",
-    priority: 0.7,
+    lastModified: REVISED.cases,
+    changeFrequency: "yearly",
+    priority: casePriority(c),
   }));
 
   const insights: MetadataRoute.Sitemap = ARTICLES.map((a) => ({

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -2,9 +2,14 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { ArrowLeft, ArrowRight, ArrowUpRight, Check } from "lucide-react";
-import { CASES, getCaseBySlug, getNextCase } from "@/lib/work";
+import { CASES, getCaseBySlug, getRelatedCase } from "@/lib/work";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { CALENDLY_URL } from "@/lib/site";
 import { CaseThumb } from "@/components/work/CaseThumb";
 import { FinalCta } from "@/components/site/FinalCta";
+import { JsonLd } from "@/components/site/JsonLd";
+import { breadcrumbSchema, caseStudySchema, graph } from "@/lib/schema";
 
 export function generateStaticParams() {
   return CASES.map((c) => ({ slug: c.slug }));
@@ -17,17 +22,30 @@ export function generateMetadata({
 }): Metadata {
   const c = getCaseBySlug(params.slug);
   if (!c) return { title: "Case study" };
-  return { title: c.name, description: `${c.name}: ${c.oneLiner}` };
+  return {
+    title: `${c.name} case study`,
+    description: c.oneLiner,
+    alternates: { canonical: `/work/${c.slug}` },
+  };
 }
 
 export default function CasePage({ params }: { params: { slug: string } }) {
   const c = getCaseBySlug(params.slug);
   if (!c) notFound();
 
-  const next = getNextCase(c.slug);
+  const { case: next, related } = getRelatedCase(c.slug);
 
   return (
     <main>
+      <JsonLd
+        data={graph(
+          caseStudySchema(c),
+          breadcrumbSchema([
+            { name: "Work", path: "/work" },
+            { name: c.name, path: `/work/${c.slug}` },
+          ]),
+        )}
+      />
       <article>
         {/* ---- Hero ---- */}
         <header className="relative overflow-hidden border-b border-faint pb-12 pt-[80px] max-md:pt-12">
@@ -317,6 +335,37 @@ export default function CasePage({ params }: { params: { slug: string } }) {
           </section>
         )}
 
+        {/* ---- Inline CTA — placed right after the outcome, at peak belief.
+             The page runs ~2,000 words and previously offered nothing to click
+             until the footer. ---- */}
+        <section className="border-t border-faint py-14 max-md:py-10">
+          <div className="wrap">
+            <div
+              data-reveal
+              className="flex items-center justify-between gap-8 rounded-xl border border-subtle bg-surface-1 p-8 shadow-[var(--shadow-sm),var(--inner-top)] max-md:flex-col max-md:items-start max-md:gap-6 max-md:p-7"
+            >
+              <div>
+                <h2 className="text-[clamp(1.15rem,1rem+0.6vw,1.4rem)] font-semibold tracking-[-0.01em] text-primary">
+                  Working on something similar?
+                </h2>
+                <p className="mt-2 max-w-[52ch] text-[14px] leading-relaxed text-secondary">
+                  Tell us where your product is today. Thirty minutes with a senior
+                  engineer, and a straight answer on whether we&rsquo;re the right fit.
+                </p>
+              </div>
+              <a
+                href={CALENDLY_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                data-cta="book-call-case-study"
+                className={cn(buttonVariants({ size: "lg" }), "shrink-0 max-md:w-full")}
+              >
+                Book a scoping call
+              </a>
+            </div>
+          </div>
+        </section>
+
         {/* ---- Next project ---- */}
         <section className="border-t border-faint py-16 max-md:py-12">
           <div className="wrap">
@@ -330,7 +379,7 @@ export default function CasePage({ params }: { params: { slug: string } }) {
               </div>
               <div className="flex-1">
                 <span className="font-mono text-[11px] uppercase tracking-caps text-tertiary">
-                  Next project — {next.category}
+                  {related ? "Related work" : "Next project"} — {next.category}
                 </span>
                 <h2 className="mt-3 text-[clamp(1.5rem,1.2rem+1.2vw,2rem)] font-semibold tracking-tight text-primary">
                   {next.name}

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -4,11 +4,14 @@ import { WorkFilter } from "@/components/work/WorkFilter";
 import { Testimonials } from "@/components/site/Testimonials";
 import { FinalCta } from "@/components/site/FinalCta";
 import { getAllCases } from "@/lib/work";
+import { JsonLd } from "@/components/site/JsonLd";
+import { breadcrumbSchema, graph } from "@/lib/schema";
 
 export const metadata: Metadata = {
-  title: "Work",
+  title: "SaaS & AI Development Case Studies",
   description:
-    "Branding, design, and engineering work we've delivered for our clients.",
+    "15 case studies with numbers: a 300,000-member community platform, SOC 2 Type II in 6 months, an $800k deal closed, 74% lower CRM cost, 40% faster dispatch.",
+  alternates: { canonical: "/work" },
 };
 
 export default function WorkPage() {
@@ -16,6 +19,7 @@ export default function WorkPage() {
 
   return (
     <main>
+      <JsonLd data={graph(breadcrumbSchema([{ name: "Work", path: "/work" }]))} />
       <PageHeader
         eyebrow="Selected work"
         title="Real products we've shipped."

--- a/src/components/site/AboutStory.tsx
+++ b/src/components/site/AboutStory.tsx
@@ -1,7 +1,7 @@
 const FACTS = [
   { stat: "21+", label: "products shipped to production" },
   { stat: "27", label: "five-star client reviews" },
-  { stat: "Weeks, not months", label: "AI-native build velocity" },
+  { stat: "Weeks, not months", label: "our normal build pace" },
   { stat: "Remote", label: "working with teams worldwide" },
 ];
 
@@ -32,10 +32,10 @@ export function AboutStory() {
             </p>
             <p>
               That model shows up in the work. We&apos;ve taken validated ideas to
-              revenue-ready v1s, rescued aging platforms that had stopped scaling,
-              and embedded with in-house teams as a long-term squad. The thread
-              through all of it: clear plans, weekly demoable progress, and code
-              you fully own from the first commit.
+              first releases people pay for, rescued aging apps that had stopped
+              keeping up, and embedded with in-house teams for the long run. The
+              thread through all of it: clear plans, weekly demoable progress,
+              and code you fully own from the first commit.
             </p>
           </div>
         </div>

--- a/src/components/site/AiNative.tsx
+++ b/src/components/site/AiNative.tsx
@@ -25,8 +25,8 @@ type Column = {
 const COLUMNS: Column[] = [
   {
     badge: Sparkles,
-    title: "In the products we ship",
-    blurb: "AI features that earn their place — shipped to production, not demos.",
+    title: "In the apps we ship",
+    blurb: "AI features that earn their place — shipped to real users, not demos.",
     items: [
       { icon: Search, term: "RAG & semantic search", desc: "Grounded answers over your own data." },
       { icon: Bot, term: "Agents & copilots", desc: "Task automation and in-app assistants." },
@@ -37,11 +37,11 @@ const COLUMNS: Column[] = [
   {
     badge: Cpu,
     title: "In how we build",
-    blurb: "AI woven through delivery, so a senior team ships like a much larger one.",
+    blurb: "AI across delivery, so a small senior team ships like a much larger one.",
     items: [
       { icon: ScrollText, term: "AI-assisted scoping", desc: "Specs and plans drafted in hours, not weeks." },
       { icon: Code2, term: "Code & test generation", desc: "More coverage, far less boilerplate." },
-      { icon: GitPullRequest, term: "AI-augmented review", desc: "A tireless second set of eyes on every PR." },
+      { icon: GitPullRequest, term: "AI-augmented review", desc: "A second set of eyes on every pull request." },
       { icon: Gauge, term: "Faster iteration", desc: "Prototypes in days to pressure-test ideas." },
     ],
   },
@@ -52,8 +52,8 @@ export function AiNative() {
     <section id="ai" className="border-b border-faint py-24 max-md:py-16">
       <div className="wrap">
         <SectionHead eyebrow="AI-native" title="AI, built into the product — and the process.">
-          We build intelligent products for our clients, and use AI intensively
-          across our own delivery to ship them faster.
+          We build AI into the apps we ship for clients, and use it across our
+          own delivery to move faster without adding people.
         </SectionHead>
 
         <div className="grid grid-cols-2 gap-5 max-md:grid-cols-1 max-md:gap-4">

--- a/src/components/site/Analytics.tsx
+++ b/src/components/site/Analytics.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect } from "react";
+import Script from "next/script";
+
+/**
+ * Analytics + conversion tracking.
+ *
+ * The site had no measurement of any kind, which meant no conversion rate, no
+ * traffic source, and no way to tell whether any marketing change worked. This
+ * is the smallest thing that fixes that.
+ *
+ * Provider-agnostic and fully env-gated — with no env vars set it renders
+ * nothing and costs nothing, so local dev and previews stay clean.
+ *
+ *   NEXT_PUBLIC_PLAUSIBLE_DOMAIN=devaxl.com   # privacy-first, no cookie banner
+ *   NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX            # GA4, if you need Google Ads later
+ *
+ * Set either, or both. Plausible is the recommended default for this site: it
+ * needs no consent banner in the EU/UK, which matters because a cookie prompt
+ * on a premium studio homepage costs conversions.
+ *
+ * CONVERSION EVENTS
+ * Any element carrying `data-cta="<name>"` is tracked on click — no per-component
+ * wiring, no server components forced into client components. The tracked CTAs
+ * are the ones that actually represent pipeline:
+ *   book-call-hero · book-call-nav · book-call-final · book-call-engagement
+ *   contact-form-submit · email-click · phone-click
+ */
+
+const PLAUSIBLE_DOMAIN = process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN;
+const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
+
+declare global {
+  interface Window {
+    plausible?: (event: string, opts?: { props?: Record<string, string> }) => void;
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+/** Fire a conversion event to whichever providers are configured. */
+export function trackEvent(name: string, props: Record<string, string> = {}) {
+  if (typeof window === "undefined") return;
+  window.plausible?.(name, Object.keys(props).length ? { props } : undefined);
+  window.gtag?.("event", name, props);
+}
+
+export function Analytics() {
+  // One delegated listener for every [data-cta] on the page, present or future.
+  useEffect(() => {
+    if (!PLAUSIBLE_DOMAIN && !GA_ID) return;
+
+    const onClick = (e: MouseEvent) => {
+      const el = (e.target as HTMLElement | null)?.closest<HTMLElement>("[data-cta]");
+      if (!el) return;
+      trackEvent(el.dataset.cta!, { location: window.location.pathname });
+    };
+
+    document.addEventListener("click", onClick, { capture: true });
+    return () => document.removeEventListener("click", onClick, { capture: true });
+  }, []);
+
+  return (
+    <>
+      {PLAUSIBLE_DOMAIN ? (
+        <Script
+          defer
+          data-domain={PLAUSIBLE_DOMAIN}
+          src="https://plausible.io/js/script.js"
+          strategy="afterInteractive"
+        />
+      ) : null}
+
+      {GA_ID ? (
+        <>
+          <Script
+            src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+            strategy="afterInteractive"
+          />
+          <Script id="ga4-init" strategy="afterInteractive">
+            {`window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}
+gtag('js',new Date());gtag('config','${GA_ID}');`}
+          </Script>
+        </>
+      ) : null}
+    </>
+  );
+}

--- a/src/components/site/Capabilities.tsx
+++ b/src/components/site/Capabilities.tsx
@@ -6,20 +6,20 @@ const CARDS = [
   {
     icon: Rocket,
     title: "SaaS & AI MVP → launch",
-    out: "Take an idea to a production v1 real users can pay for — AI features built in where they matter, scoped tight, shipped in weeks not quarters.",
-    outcome: "Outcome: a live, revenue-ready product",
+    out: "Take an idea to a first release real users can pay for — AI built in where it earns its place, scoped tight, delivered to the plan we agreed.",
+    outcome: "Outcome: a live app people can pay for",
   },
   {
     icon: Gauge,
     title: "Scale & modernize",
-    out: "Tame a slow, brittle codebase serving thousands of users — performance, reliability, and a roadmap you can build on.",
-    outcome: "Outcome: faster, stable, maintainable",
+    out: "Take ownership of a slow, buggy codebase serving thousands of users — speed, reliability, and a roadmap you can build on.",
+    outcome: "Outcome: fast, stable, easy to extend",
   },
   {
     icon: Users,
     title: "Embed a product team",
-    out: "A dedicated squad — design, engineering, PM — that works as part of your org against your roadmap, sprint after sprint.",
-    outcome: "Outcome: durable delivery velocity",
+    out: "A dedicated senior team — design, engineering, PM — that works inside your org against your roadmap, week after week.",
+    outcome: "Outcome: steady, predictable delivery",
   },
 ];
 
@@ -28,8 +28,8 @@ export function Capabilities() {
     <section id="services" className="border-b border-faint py-24 max-md:py-16">
       <div className="wrap">
         <SectionHead eyebrow="Services" title="One senior team, from first commit to scale.">
-          We plug in where you need us — a fast v1, a rescue mission on an aging
-          platform, or a long-term embedded squad.
+          We plug in where you need us — a first release, a rescue on an app
+          that has gone brittle, or a long-term embedded team.
         </SectionHead>
 
         <div className="grid grid-cols-3 gap-5 max-md:grid-cols-1 max-md:gap-4">

--- a/src/components/site/ContactForm.tsx
+++ b/src/components/site/ContactForm.tsx
@@ -3,7 +3,8 @@
 import { useState } from "react";
 import { ArrowRight, CheckCircle2, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { CONTACT } from "@/lib/site";
+import { CALENDLY_URL, CONTACT } from "@/lib/site";
+import { trackEvent } from "@/components/site/Analytics";
 
 type Status = "idle" | "submitting" | "success" | "error";
 
@@ -43,10 +44,12 @@ export function ContactForm() {
       const data = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
       if (res.ok && data.ok) {
         setStatus("success");
+        // Counted on delivery, not on click — a submit that errored isn't a lead.
+        trackEvent("contact-form-submit");
         form.reset();
       } else {
         setStatus("error");
-        setError(data.error ?? "Something went wrong. Please try again.");
+        setError(data.error ?? "That didn't send. Try again, or email us.");
       }
     } catch {
       setStatus("error");
@@ -68,8 +71,17 @@ export function ContactForm() {
           Message sent.
         </h3>
         <p className="mt-1.5 max-w-[40ch] text-[14px] text-secondary">
-          Thanks for reaching out — we&apos;ll reply within one business day. Prefer
-          to talk sooner? Book a call or email{" "}
+          We&apos;ll reply within one business day. Want to talk sooner?{" "}
+          <a
+            href={CALENDLY_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-cta="book-call-success"
+            className="text-accent hover:underline"
+          >
+            Book a scoping call
+          </a>
+          , or email{" "}
           <a href={CONTACT.emailHref} className="text-accent hover:underline">
             {CONTACT.email}
           </a>
@@ -151,7 +163,7 @@ export function ContactForm() {
 
       <div className="mt-4">
         <label htmlFor="cf-message" className={LABEL}>
-          What are you building?
+          What are you working on?
         </label>
         <textarea
           id="cf-message"
@@ -159,7 +171,7 @@ export function ContactForm() {
           required
           minLength={10}
           rows={5}
-          placeholder="A sentence or two on your product, stage, and where you'd like help."
+          placeholder="Even two lines helps — what you're building or fixing, and what's stuck."
           className={FIELD + " resize-y"}
         />
       </div>
@@ -179,7 +191,7 @@ export function ContactForm() {
             </>
           ) : (
             <>
-              Send message
+              Get our take
               <ArrowRight strokeWidth={2} />
             </>
           )}

--- a/src/components/site/Engagement.tsx
+++ b/src/components/site/Engagement.tsx
@@ -8,31 +8,34 @@ import { SectionHead } from "./SectionHead";
 const TIERS = [
   {
     name: "MVP Build",
-    who: "For founders taking a validated idea to a production v1.",
+    cta_id: "book-call-mvp",
+    who: "For founders taking a validated idea to a working first release.",
     points: [
       "Fixed-scope, fixed-timeline delivery",
       "Design, engineering & QA included",
-      "Live, revenue-ready product",
+      "A live app people can pay for",
     ],
-    cta: "Start a build",
+    cta: "Scope your v1",
     featured: false,
   },
   {
     name: "Dedicated Team",
+    cta_id: "book-call-team",
     who: "For teams that need durable velocity against an evolving roadmap.",
     points: [
-      "Embedded senior squad, monthly",
+      "Embedded senior team, monthly",
       "Design + frontend + backend + PM",
-      "Works inside your tools & rituals",
+      "Works inside your Slack and tools",
     ],
-    cta: "Build a team",
+    cta: "Plan your team",
     featured: true,
   },
   {
     name: "Modernization Retainer",
-    who: "For platforms that need to get faster, stabler, and easier to extend.",
+    cta_id: "book-call-retainer",
+    who: "For an app that has to get faster, steadier, and easier to extend.",
     points: [
-      "Performance & reliability program",
+      "Performance & reliability work",
       "Incremental, zero-downtime rollout",
       "Ongoing architecture guidance",
     ],
@@ -83,6 +86,7 @@ export function Engagement() {
                 href={CALENDLY_URL}
                 target="_blank"
                 rel="noopener noreferrer"
+                data-cta={t.cta_id}
                 className={cn(
                   buttonVariants({ variant: t.featured ? "primary" : "ghost" }),
                   "w-full",

--- a/src/components/site/Faq.tsx
+++ b/src/components/site/Faq.tsx
@@ -2,30 +2,8 @@
 
 import { useState } from "react";
 import { Plus } from "lucide-react";
+import { FAQS } from "@/lib/faq";
 import { SectionHead } from "./SectionHead";
-
-const FAQS = [
-  {
-    q: "How does an engagement start?",
-    a: "Every engagement opens with a short scoping call, then a fixed-fee discovery: we pressure-test the problem, agree on success metrics, and return a written plan with scope, timeline, and team. You decide to proceed with full information — no open-ended retainers to find out what you are buying.",
-  },
-  {
-    q: "What do typical timelines look like?",
-    a: "A focused MVP reaches a production v1 in roughly 8–12 weeks. Modernization and embedded-team work run continuously in two-week increments you can use and review each sprint. We commit to dates in writing and report against them weekly.",
-  },
-  {
-    q: "Who owns the IP and the code?",
-    a: "You do — fully. All code, design, and infrastructure are yours from day one, delivered in your repositories and cloud accounts. We work under standard work-for-hire terms with mutual NDAs, and we never reuse client code across engagements.",
-  },
-  {
-    q: "How is the team structured?",
-    a: "You work with a single senior squad — design, engineering, and product — led by an accountable engagement lead. No layers of account managers, no junior hand-offs. The people on your kickoff call are the people who ship.",
-  },
-  {
-    q: "How do you use AI — in the product, or in delivery?",
-    a: "Both. We build AI into the products we ship — RAG and semantic search, agents and copilots, LLM pipelines, and the evals and guardrails that keep them accurate, safe, and cost-controlled in production. And we use AI intensively across our own delivery — scoping, code and test generation, and review — so a small senior team ships like a much larger one. AI features go in only where they earn their place, never as a checkbox.",
-  },
-];
 
 function FaqItem({ q, a }: { q: string; a: string }) {
   const [open, setOpen] = useState(false);

--- a/src/components/site/FinalCta.tsx
+++ b/src/components/site/FinalCta.tsx
@@ -27,21 +27,27 @@ export function FinalCta() {
         }}
       />
       <div className="wrap relative" data-reveal>
-        <h2 className="t-display mx-auto max-w-[760px]">Ready to ship your product?</h2>
-        <p className="mx-auto mt-5 max-w-[520px] text-[18px] text-secondary max-md:text-[16px]">
-          Tell us where your product is today. We&rsquo;ll tell you exactly how
-          we&rsquo;d help.
+        <h2 className="t-display mx-auto max-w-[760px]">Hand it over. We&rsquo;ll take it from here.</h2>
+        <p className="mx-auto mt-5 max-w-[600px] text-[18px] leading-[1.6] text-secondary max-md:text-[16px]">
+          Tell us where your product is today &mdash; or what went wrong last time.
+          In 30 minutes you&rsquo;ll get a straight answer on whether we&rsquo;re the
+          right team to own it, backed by 27 five-star client reviews.
         </p>
         <div className="mt-9 flex justify-center gap-3.5 max-md:flex-col max-md:items-stretch">
           <a
             href={CALENDLY_URL}
             target="_blank"
             rel="noopener noreferrer"
+            data-cta="book-call-final"
             className={cn(buttonVariants({ size: "lg" }), "max-md:w-full")}
           >
             Book a scoping call
           </a>
-          <Link href="/work" className={cn(buttonVariants({ variant: "ghost", size: "lg" }), "max-md:w-full")}>
+          <Link
+            href="/work"
+            data-cta="see-work-final"
+            className={cn(buttonVariants({ variant: "ghost", size: "lg" }), "max-md:w-full")}
+          >
             See our work
           </Link>
         </div>

--- a/src/components/site/Footer.tsx
+++ b/src/components/site/Footer.tsx
@@ -64,12 +64,14 @@ export function Footer() {
             </h2>
             <a
               href={CONTACT.emailHref}
+              data-cta="email-click"
               className="mb-[11px] block text-[14px] text-secondary transition-colors duration-[120ms] hover:text-primary"
             >
               {CONTACT.email}
             </a>
             <a
               href={CONTACT.phoneHref}
+              data-cta="phone-click"
               className="mb-[11px] block text-[14px] text-secondary transition-colors duration-[120ms] hover:text-primary"
             >
               {CONTACT.phone}
@@ -78,6 +80,7 @@ export function Footer() {
               href={CALENDLY_URL}
               target="_blank"
               rel="noopener noreferrer"
+              data-cta="book-call-footer"
               className="mb-[11px] block text-[14px] text-secondary transition-colors duration-[120ms] hover:text-primary"
             >
               Book a call

--- a/src/components/site/Hero.tsx
+++ b/src/components/site/Hero.tsx
@@ -66,23 +66,34 @@ export function Hero() {
             <span className="text-accent">SaaS &amp; AI products.</span>
           </h1>
           <p className="mt-6 max-w-[540px] text-[18px] leading-[1.65] text-secondary max-md:text-[16px]">
-            From AI-powered features to platforms serving thousands of users — we
-            embed a senior, AI-native product team and ship. We build AI into the
-            product, and use it across how we deliver.
+            We take the problem off your desk and own it through to production —
+            one senior squad, no hand-offs, and a demo you can click through every
+            week. Production v1 in 8&ndash;12 weeks, in your repos, yours from day one.
           </p>
           <div className="mt-9 flex flex-wrap gap-3.5 max-md:flex-col max-md:items-stretch">
-            <Link href="/work" className={cn(buttonVariants({ size: "lg" }), "max-md:w-full")}>
-              See what we&rsquo;ve shipped
-            </Link>
             <a
               href={CALENDLY_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className={cn(buttonVariants({ variant: "ghost", size: "lg" }), "max-md:w-full")}
+              data-cta="book-call-hero"
+              className={cn(buttonVariants({ size: "lg" }), "max-md:w-full")}
             >
               Book a scoping call
             </a>
+            <Link
+              href="/work"
+              data-cta="see-work-hero"
+              className={cn(buttonVariants({ variant: "ghost", size: "lg" }), "max-md:w-full")}
+            >
+              See what we&rsquo;ve shipped
+            </Link>
           </div>
+          {/* Risk reversal directly under the primary CTA — the top objection for
+              a studio is "am I about to be sold to for 30 minutes?" */}
+          <p className="mt-4 text-[13.5px] leading-relaxed text-tertiary">
+            30 minutes with a senior engineer, not a salesperson. No pitch deck, no
+            obligation &mdash; and you own every line of code we write.
+          </p>
         </div>
 
         <ProductShowcase />

--- a/src/components/site/Industries.tsx
+++ b/src/components/site/Industries.tsx
@@ -4,18 +4,21 @@ import {
   Landmark,
   Sparkles,
   Store,
-  Wrench,
+  Truck,
 } from "lucide-react";
 import { SpotlightCard } from "@/components/ui/SpotlightCard";
 import { SectionHead } from "./SectionHead";
 
+// Ordered by depth of evidence in /work, not by what sounds impressive.
+// Logistics leads because five case studies back it — Apolloe (TMS), Carrier
+// Network, Chat Center, Driver App, and Trucking Guru.
 const INDUSTRIES = [
-  { icon: Landmark, label: "Fintech", desc: "Payments, ledgers, and compliance-grade flows." },
+  { icon: Truck, label: "Logistics & fleet", desc: "TMS, dispatch, carrier data, and driver safety." },
   { icon: Boxes, label: "B2B SaaS", desc: "Multi-tenant apps, billing, and dashboards." },
-  { icon: HeartPulse, label: "Health", desc: "Records, scheduling, and HIPAA-aware systems." },
-  { icon: Store, label: "Marketplaces", desc: "Matching, payouts, and trust & safety." },
   { icon: Sparkles, label: "AI", desc: "RAG, agents, and model integration." },
-  { icon: Wrench, label: "Internal tools", desc: "Admin consoles, ops, and automation." },
+  { icon: Landmark, label: "Fintech", desc: "Payments, ledgers, and compliance-grade flows." },
+  { icon: Store, label: "Marketplaces", desc: "Matching, payouts, and trust & safety." },
+  { icon: HeartPulse, label: "Health", desc: "Records, scheduling, and HIPAA-aware systems." },
 ];
 
 export function Industries() {

--- a/src/components/site/JsonLd.tsx
+++ b/src/components/site/JsonLd.tsx
@@ -1,0 +1,16 @@
+/**
+ * Renders a JSON-LD block. Server component — the markup ships in the initial
+ * HTML so crawlers and LLM fetchers see it without executing JavaScript.
+ */
+export function JsonLd({ data }: { data: unknown }) {
+  return (
+    <script
+      type="application/ld+json"
+      // JSON.stringify output is injected verbatim; `<` is escaped so a stray
+      // "</script>" inside any content string can't break out of the tag.
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(data).replace(/</g, "\\u003c"),
+      }}
+    />
+  );
+}

--- a/src/components/site/Nav.tsx
+++ b/src/components/site/Nav.tsx
@@ -113,6 +113,7 @@ export function Nav() {
             href={CALENDLY_URL}
             target="_blank"
             rel="noopener noreferrer"
+            data-cta="book-call-nav"
             className={cn(buttonVariants({ size: "sm" }), "max-md:h-10")}
           >
             Book a call

--- a/src/components/site/Principles.tsx
+++ b/src/components/site/Principles.tsx
@@ -36,7 +36,7 @@ const PRINCIPLES: Principle[] = [
   {
     icon: Sparkles,
     title: "AI-native, end to end",
-    body: "We build AI into the products we ship, and use it intensively across delivery — so a small senior team moves with the velocity of a much larger one.",
+    body: "We build AI into the apps we ship, and use it across delivery — so a small senior team gets through the work of a much larger one.",
   },
   {
     icon: HeartHandshake,

--- a/src/components/site/Process.tsx
+++ b/src/components/site/Process.tsx
@@ -7,10 +7,10 @@ import { SectionHead } from "./SectionHead";
 
 const STEPS = [
   { n: "01", title: "Discovery", body: "We pressure-test the problem, scope, and success metrics before a line of code." },
-  { n: "02", title: "Design", body: "Flows and interfaces designed against the real product, not throwaway mockups." },
+  { n: "02", title: "Design", body: "Flows and screens designed against the real app, not throwaway mockups." },
   { n: "03", title: "Build", body: "Senior engineers ship in tight, demoable increments you can use every week." },
   { n: "04", title: "Launch", body: "Production-hardened release — monitoring, CI/CD, and a runbook from day one." },
-  { n: "05", title: "Scale", body: "We stay on to optimize, harden, and extend as your user base grows." },
+  { n: "05", title: "Scale", body: "We stay on to speed up, harden, and extend as your user base grows." },
 ];
 
 export function Process() {

--- a/src/components/site/Proof.tsx
+++ b/src/components/site/Proof.tsx
@@ -1,7 +1,16 @@
 import { Counter } from "@/components/ui/Counter";
 import { Marquee } from "@/components/ui/Marquee";
 
-const CLIENTS = [1, 2, 3, 4, 5, 6];
+// Company name shown in each logo, used for alt text so screen readers and
+// search engines get a name instead of "Devaxl client 1".
+const CLIENTS = [
+  { n: 1, name: "Techno Line" },
+  { n: 2, name: "Montorin" },
+  { n: 3, name: "Arrow Market" },
+  { n: 4, name: "Maxin Graphic" },
+  { n: 5, name: "Sontara" },
+  { n: 6, name: "Altra Technology" },
+];
 
 export function Proof() {
   return (
@@ -10,12 +19,12 @@ export function Proof() {
         {/* Real client logo wall */}
         <div className="mb-10 flex items-center gap-4" data-reveal>
           <Marquee>
-            {CLIENTS.map((n) => (
+            {CLIENTS.map((c) => (
               // eslint-disable-next-line @next/next/no-img-element
               <img
-                key={n}
-                src={`/clients/client${n}.png`}
-                alt={`Devaxl client ${n}`}
+                key={c.n}
+                src={`/clients/client${c.n}.png`}
+                alt={`${c.name} — Devaxl client`}
                 loading="lazy"
                 className="h-8 w-auto object-contain"
               />

--- a/src/components/site/SelectedWork.tsx
+++ b/src/components/site/SelectedWork.tsx
@@ -17,8 +17,8 @@ export function SelectedWork() {
     <section id="work" className="border-b border-faint py-24 max-md:py-16">
       <div className="wrap">
         <SectionHead eyebrow="Selected work" title="Real products we've shipped.">
-          Design, branding, and engineering work delivered for our clients.
-          Outcome metrics are coming as clients confirm them.
+          Fifteen case studies with the problem, the approach, and the outcome —
+          a 300,000-member platform, 74% lower CRM cost, dispatch 40% faster.
         </SectionHead>
 
         <div className="grid grid-cols-2 gap-6 max-md:grid-cols-1 max-md:gap-[18px]">

--- a/src/components/site/TechStack.tsx
+++ b/src/components/site/TechStack.tsx
@@ -34,8 +34,8 @@ export function TechStack() {
     <section className="border-b border-faint py-24 max-md:py-16">
       <div className="wrap">
         <SectionHead eyebrow="Stack" title="The tools we build and ship with.">
-          A modern, AI-native stack chosen for what lasts — not what&apos;s
-          trending. We pick the right tool for your product, not a house template.
+          A modern stack chosen for what lasts — not what&apos;s trending. We
+          pick the right tool for your app, not whatever our last project used.
         </SectionHead>
 
         <div className="grid grid-cols-4 gap-5 max-lg:grid-cols-2 max-sm:grid-cols-1 max-md:gap-4">

--- a/src/lib/faq.ts
+++ b/src/lib/faq.ts
@@ -1,0 +1,40 @@
+// FAQ content lives here (not inside the component) so the visible accordion and
+// the FAQPage JSON-LD are rendered from the same source. Google requires schema
+// to match what's on the page — one array guarantees it can't drift.
+
+export type Faq = { q: string; a: string };
+
+export const FAQS: Faq[] = [
+  {
+    q: "How does an engagement start?",
+    a: "Every engagement opens with a short scoping call, then a fixed-fee discovery: we pressure-test the problem, agree on success metrics, and return a written plan with scope, timeline, and team. You decide to proceed with full information — no open-ended retainers to find out what you are buying.",
+  },
+  {
+    q: "How much does an engagement cost?",
+    a: "Discovery is a fixed fee, and it produces a written plan with the full build cost in it before you commit to anything. Builds are quoted as fixed scope for a fixed price; embedded teams and modernization work run as a monthly retainer sized to the squad. We share real numbers on the scoping call — the answer depends on scope, and we would rather quote your project than a range that fits nobody.",
+  },
+  {
+    q: "How long does it take to build an MVP?",
+    a: "A focused MVP reaches a production v1 in roughly 8–12 weeks. Modernization and embedded-team work run continuously in two-week increments you can use and review each sprint. We commit to dates in writing and report against them weekly.",
+  },
+  {
+    q: "Who owns the IP and the code?",
+    a: "You do — fully. All code, design, and infrastructure are yours from day one, delivered in your repositories and cloud accounts. We work under standard work-for-hire terms with mutual NDAs, and we never reuse client code across engagements.",
+  },
+  {
+    q: "Who actually works on my project?",
+    a: "You work with a single senior squad — design, engineering, and product — led by an accountable engagement lead. No layers of account managers, no junior hand-offs. The people on your kickoff call are the people who ship.",
+  },
+  {
+    q: "You're remote — how does that work across time zones?",
+    a: "We overlap with your working hours for standups, demos, and anything that needs a real conversation, and we work asynchronously in your tools — your repo, your tracker, your Slack — the rest of the time. Clients get a weekly demo they can click through and a written status against the plan, so progress is visible without needing a meeting to find it.",
+  },
+  {
+    q: "What happens if it isn't working out?",
+    a: "Retainers run month to month with a 30-day notice — no long lock-in — and whatever we've built is already in your repositories and cloud accounts, so leaving costs you nothing but the notice period. Discovery is deliberately the first commitment, so you see how we scope, write, and communicate before signing a build.",
+  },
+  {
+    q: "How do you use AI — in the product, or in delivery?",
+    a: "Both. We build AI into the products we ship — RAG and semantic search, agents and copilots, LLM pipelines, and the evals and guardrails that keep them accurate, safe, and cost-controlled in production. And we use AI intensively across our own delivery — scoping, code and test generation, and review — so a small senior team ships like a much larger one. AI features go in only where they earn their place, never as a checkbox.",
+  },
+];

--- a/src/lib/insights.ts
+++ b/src/lib/insights.ts
@@ -1,6 +1,14 @@
 // Insights (blog) content. These 3 articles are SEED PLACEHOLDERS — replace
 // the prose, dates, authors, and cover/thumbnail media with real content.
-// Each is tagged [PLACEHOLDER: real article] in the UI.
+//
+// WARNING: there is no visible placeholder marker. An earlier version of this
+// comment claimed each article "is tagged [PLACEHOLDER: real article] in the UI"
+// — that tag was never implemented. These render as finished, dated articles,
+// they are in the sitemap, and they now carry BlogPosting structured data
+// (src/lib/schema.ts) that asserts their datePublished and author to search
+// engines and LLMs. Either byline them to a real person and treat them as
+// published, or pull /insights from the nav and sitemap until real articles
+// exist. Leaving them as-is publishes seed content under the Devaxl name.
 
 export type ArticleBlock =
   | { type: "p"; text: string }

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,0 +1,218 @@
+// schema.org JSON-LD builders.
+//
+// Rules we hold to here:
+//  - Only mark up things that are actually visible on the page.
+//  - No aggregateRating / Review on our own Organization. Google's review-snippet
+//    guidelines make a page ineligible for the star review feature when the entity
+//    being reviewed controls the reviews about itself, so self-serving markup here
+//    would buy nothing — and our reviews live on Upwork and Fiverr anyway.
+//  - Everything is server-rendered so crawlers and LLMs see it without JS.
+
+import { CONTACT, SOCIALS } from "@/lib/site";
+import { FAQS } from "@/lib/faq";
+
+export const SITE_URL = "https://devaxl.com";
+
+const abs = (path: string) => new URL(path, SITE_URL).toString();
+
+export const ORG_ID = `${SITE_URL}/#organization`;
+export const SITE_ID = `${SITE_URL}/#website`;
+
+/** The company entity. Referenced by @id from every other node. */
+export function organizationSchema() {
+  return {
+    "@type": "Organization",
+    "@id": ORG_ID,
+    name: "Devaxl",
+    alternateName: "Devaxl Solutions",
+    url: SITE_URL,
+    logo: {
+      "@type": "ImageObject",
+      url: abs("/devaxl-logo.png"),
+    },
+    image: abs("/devaxl-logo.png"),
+    slogan: "Development accelerated",
+    description:
+      "An AI-native product studio that designs, builds, and scales SaaS and AI products for founders and CTOs — MVP builds, embedded product teams, and platform modernization.",
+    email: CONTACT.email,
+    telephone: CONTACT.phone,
+    sameAs: SOCIALS.map((s) => s.href),
+    // Topic entity-linking for AI engines. Every value here is something the
+    // site actually shows: the six Industries cards, the four TechStack groups,
+    // and the AI-native columns. Nothing inferred, nothing aspirational.
+    knowsAbout: [
+      "SaaS product development",
+      "AI product engineering",
+      "Retrieval-augmented generation",
+      "AI agents and copilots",
+      "LLM evaluation and guardrails",
+      "Platform modernization",
+      "Logistics and fleet software",
+      "Transportation management systems",
+      "B2B SaaS platforms",
+      "Fintech engineering",
+      "Marketplace platforms",
+      "Healthcare software",
+      "React and Next.js",
+      "Node.js",
+      "AWS cloud infrastructure",
+    ],
+    // "Remote, worldwide" — stated on the contact page and in public/llms.txt.
+    // Same claim the Service nodes already carry.
+    areaServed: "Worldwide",
+    contactPoint: [
+      {
+        "@type": "ContactPoint",
+        contactType: "sales",
+        email: CONTACT.email,
+        telephone: CONTACT.phone,
+        availableLanguage: ["English"],
+      },
+    ],
+  };
+}
+
+/** The site entity, so search engines can attribute pages to one property. */
+export function websiteSchema() {
+  return {
+    "@type": "WebSite",
+    "@id": SITE_ID,
+    url: SITE_URL,
+    name: "Devaxl",
+    publisher: { "@id": ORG_ID },
+    inLanguage: "en",
+  };
+}
+
+/**
+ * The three engagement models, as they appear on /services.
+ * No `offers` node — we publish no prices, and inventing them would make the
+ * markup inaccurate. Add `offers` here the day a price signal ships.
+ */
+export function servicesSchema() {
+  const services = [
+    {
+      name: "SaaS & AI MVP build",
+      description:
+        "Take an idea to a first release real users can pay for — AI built in where it earns its place, scoped tight, delivered to the plan we agreed.",
+    },
+    {
+      name: "Scale & modernization",
+      description:
+        "Take ownership of a slow, buggy codebase serving thousands of users — speed, reliability, and a roadmap you can build on.",
+    },
+    {
+      name: "Embedded product team",
+      description:
+        "A dedicated senior team — design, engineering, PM — that works inside your org against your roadmap, week after week.",
+    },
+  ];
+
+  return services.map((s) => ({
+    "@type": "Service",
+    name: s.name,
+    description: s.description,
+    serviceType: "Software product engineering",
+    audience: {
+      "@type": "Audience",
+      audienceType: "Founders and CTOs at seed to Series-B software companies",
+    },
+    provider: { "@id": ORG_ID },
+    areaServed: "Worldwide",
+    url: abs("/services"),
+  }));
+}
+
+/** FAQPage built from the same array the accordion renders. */
+export function faqSchema(items: { q: string; a: string }[] = FAQS) {
+  return {
+    "@type": "FAQPage",
+    mainEntity: items.map((f) => ({
+      "@type": "Question",
+      name: f.q,
+      acceptedAnswer: { "@type": "Answer", text: f.a },
+    })),
+  };
+}
+
+/** Breadcrumbs for nested pages. Pass the trail excluding "Home". */
+export function breadcrumbSchema(trail: { name: string; path: string }[]) {
+  return {
+    "@type": "BreadcrumbList",
+    itemListElement: [{ name: "Home", path: "/" }, ...trail].map((c, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: c.name,
+      item: abs(c.path),
+    })),
+  };
+}
+
+/** Blog posts on /insights/[slug]. */
+export function articleSchema(a: {
+  slug: string;
+  title: string;
+  dek: string;
+  dateISO: string;
+  author: string;
+  category: string;
+}) {
+  const url = abs(`/insights/${a.slug}`);
+  return {
+    "@type": "BlogPosting",
+    "@id": `${url}#article`,
+    mainEntityOfPage: url,
+    url,
+    headline: a.title,
+    description: a.dek,
+    articleSection: a.category,
+    datePublished: a.dateISO,
+    dateModified: a.dateISO,
+    inLanguage: "en",
+    author: { "@type": "Organization", name: a.author, url: SITE_URL },
+    publisher: { "@id": ORG_ID },
+    // Articles render a generated cover glyph rather than a stored image file,
+    // so we point at the brand logo — a real asset — instead of a 404.
+    image: abs("/devaxl-logo.png"),
+  };
+}
+
+/** Case studies on /work/[slug]. */
+export function caseStudySchema(c: {
+  slug: string;
+  name: string;
+  oneLiner: string;
+  categories?: string[];
+  thumbnail?: string;
+}) {
+  const url = abs(`/work/${c.slug}`);
+  return {
+    "@type": "Article",
+    "@id": `${url}#case-study`,
+    mainEntityOfPage: url,
+    url,
+    headline: `${c.name} — case study`,
+    description: c.oneLiner,
+    // Tells an engine what kind of article this is without it having to guess
+    // from the URL, and ties the page back to the one site entity.
+    articleSection: "Case study",
+    inLanguage: "en",
+    isPartOf: { "@id": SITE_ID },
+    author: { "@id": ORG_ID },
+    publisher: { "@id": ORG_ID },
+    // The same discipline chips the page renders in the hero — no new claims.
+    ...(c.categories?.length ? { keywords: c.categories.join(", ") } : {}),
+    // One case (BRB) has no screenshot and renders a generated poster, so we
+    // fall back to the brand logo — a real asset — instead of omitting image
+    // and leaving the node without one.
+    image: c.thumbnail ? abs(c.thumbnail) : abs("/devaxl-logo.png"),
+  };
+}
+
+/** Wrap any set of nodes into a single @graph document. */
+export function graph(...nodes: unknown[]) {
+  return {
+    "@context": "https://schema.org",
+    "@graph": nodes.flat(),
+  };
+}

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,6 +1,9 @@
 // Real DevAXL contact + booking details (from devaxl.com).
 
-export const CALENDLY_URL = "https://calendly.com/touqeerhassan";
+// Points at the 30-minute scoping-call event specifically, so the booking page
+// opens on the right event type instead of the profile's event list. Every CTA
+// on the site imports this one constant.
+export const CALENDLY_URL = "https://calendly.com/touqeerhassan/30min";
 
 export const CONTACT = {
   email: "sales@devaxl.com",

--- a/src/lib/work.ts
+++ b/src/lib/work.ts
@@ -6,6 +6,7 @@ export type CaseStudy = {
   slug: string;
   name: string;
   categories: string[]; // real tags — also used as filter keys + chips
+  industry?: string; // vertical, used to link related cases (see getRelatedCase)
   category: string; // display string, e.g. "Branding · Web Development"
   oneLiner: string;
   overview: string;
@@ -39,6 +40,7 @@ export const WORK_FILTERS = [
 export const CASES: CaseStudy[] = [
   {
     "slug": "apolloe",
+    "industry": "Logistics",
     "name": "Apolloe",
     "categories": [
       "SaaS",
@@ -90,6 +92,7 @@ export const CASES: CaseStudy[] = [
   },
   {
     "slug": "aninja-crm",
+    "industry": "Sales & CRM",
     "name": "aNinja AI",
     "categories": [
       "SaaS",
@@ -206,6 +209,7 @@ export const CASES: CaseStudy[] = [
   },
   {
     "slug": "nrtur",
+    "industry": "Sales & CRM",
     "name": "Nrtur",
     "categories": [
       "SaaS",
@@ -275,6 +279,7 @@ export const CASES: CaseStudy[] = [
   },
   {
     "slug": "pma",
+    "industry": "Community & Media",
     "name": "Product Marketing Alliance",
     "categories": [
       "SaaS",
@@ -340,6 +345,7 @@ export const CASES: CaseStudy[] = [
   },
   {
     "slug": "securepoint360",
+    "industry": "IT & Security",
     "name": "SecurePoint 360",
     "categories": [
       "Security",
@@ -405,6 +411,7 @@ export const CASES: CaseStudy[] = [
   },
   {
     "slug": "itboost",
+    "industry": "IT & Security",
     "name": "ITBoost",
     "categories": [
       "SaaS",
@@ -453,6 +460,7 @@ export const CASES: CaseStudy[] = [
   },
   {
     "slug": "brb",
+    "industry": "Marketplace",
     "name": "BeautyRightBack (BRB)",
     "categories": [
       "AI",
@@ -514,6 +522,7 @@ export const CASES: CaseStudy[] = [
   },
   {
     "slug": "authority-alert",
+    "industry": "Marketplace",
     "name": "Authority Alert",
     "categories": [
       "SaaS",
@@ -580,6 +589,7 @@ export const CASES: CaseStudy[] = [
   },
   {
     "slug": "carrier-network",
+    "industry": "Logistics",
     "name": "Carrier Network",
     "categories": [
       "SaaS",
@@ -642,6 +652,7 @@ export const CASES: CaseStudy[] = [
   },
   {
     "slug": "trucking-guru",
+    "industry": "Logistics",
     "name": "Trucking Guru",
     "categories": [
       "Branding",
@@ -707,6 +718,7 @@ export const CASES: CaseStudy[] = [
   },
   {
     "slug": "chat-center",
+    "industry": "Logistics",
     "name": "Chat Center",
     "categories": [
       "SaaS",
@@ -773,6 +785,7 @@ export const CASES: CaseStudy[] = [
   },
   {
     "slug": "driver-app",
+    "industry": "Logistics",
     "name": "Driver App",
     "categories": [
       "Mobile App Development",
@@ -839,6 +852,7 @@ export const CASES: CaseStudy[] = [
   },
   {
     "slug": "sound-space",
+    "industry": "Community & Media",
     "name": "Sound Space",
     "categories": [
       "SaaS",
@@ -978,4 +992,45 @@ export function getCaseBySlug(slug: string): CaseStudy | undefined {
 export function getNextCase(slug: string): CaseStudy {
   const i = CASES.findIndex((c) => c.slug === slug);
   return CASES[(i + 1) % CASES.length];
+}
+
+/**
+ * The most closely related case, by shared discipline tags.
+ *
+ * The "next project" link used to walk the array in order, which chained all 15
+ * cases into a ring but linked them by accident of position. That left the
+ * strongest cluster on the site — five trucking and logistics builds (Apolloe,
+ * Carrier Network, Chat Center, Driver App, Trucking Guru) — with no thematic
+ * path between them. Preferring a case that shares tags means a reader deep in
+ * one logistics story is offered another, which is both better for them and the
+ * internal-linking signal that vertical was missing.
+ *
+ * Falls back to the next case in order, so every case still links somewhere and
+ * the ring property is preserved.
+ */
+export function getRelatedCase(slug: string): { case: CaseStudy; related: boolean } {
+  const current = getCaseBySlug(slug);
+  if (!current) return { case: getNextCase(slug), related: false };
+
+  const scored = CASES.filter((c) => c.slug !== slug)
+    .map((c) => ({
+      c,
+      // A shared vertical beats any number of shared disciplines: two trucking
+      // builds belong together more than two things that both happen to be SaaS.
+      shared:
+        (current.industry && c.industry === current.industry ? 10 : 0) +
+        c.categories.filter((cat) => current.categories.includes(cat)).length,
+    }))
+    .filter((x) => x.shared > 0)
+    .sort((a, b) => b.shared - a.shared);
+
+  // Rotate among equally-related cases by position, so the five logistics cases
+  // form a cycle rather than all pointing at the same one.
+  if (scored.length) {
+    const top = scored.filter((x) => x.shared === scored[0].shared).map((x) => x.c);
+    const i = CASES.findIndex((c) => c.slug === slug);
+    return { case: top[i % top.length], related: true };
+  }
+
+  return { case: getNextCase(slug), related: false };
 }


### PR DESCRIPTION
Marketing and SEO pass over the site. Fixes a canonical bug, adds the technical
layer the site was missing, and runs a text-only copy/CRO pass. 38 files, no
visual redesign — beyond five layout fixes that were approved individually.

## The main find

The root layout set `alternates: { canonical: "/" }`. Next.js merges metadata
**shallowly**, so any page that omitted the `alternates` key inherited the
homepage's canonical. Reproduced before fixing — `/work` was emitting:

```html
<link rel="canonical" href="https://devaxl.com">
```

A canonical is a strong hint rather than a directive, and it is *not* noindex —
but where Google honors it, those URLs' ranking signals consolidate onto the
homepage and the homepage is shown instead. That covered `/work`, `/services`,
`/about`, `/contact`, `/process`, `/insights` and all 18 case-study and article
pages. Fifteen case studies with real client numbers in them, handing their
authority upward instead of ranking on their own.

All nine content pages now declare their own canonical. `not-found.tsx`
deliberately does not — a 404 shouldn't be canonicalised anywhere.

## What's in here

**SEO**
- All 7 page titles rewritten. They were bare navigation labels — "Services",
  "Work", "About" — which are the most valuable strings the site has in a SERP.
- Every meta description resized to the ~160-char window; four were truncated.
- `sitemap.ts`: `lastModified` added, dated from history rather than
  `new Date()` (which tells crawlers the whole site changed on every build until
  they stop trusting the field). Priorities are now rule-based; case-study
  priority is derived from link prominence and content depth.
- `robots.ts`: disallow `/api/`, a POST-only endpoint returning 405 to crawlers.

**Structured data** — the site previously had none
- Organization, WebSite, Service ×3, FAQPage, BreadcrumbList, Article, BlogPosting.
- No `aggregateRating`/`Review`: Google makes a page ineligible for the star
  review feature when the reviewed entity controls its own reviews, and ours
  live on Upwork and Fiverr.
- `public/llms.txt` added so AI assistants can read the company without scraping.

**Analytics** — optional, off by default
- Env-gated Plausible/GA4 scaffold. With no env var set it renders nothing and
  costs nothing, so this is inert until someone decides measurement is wanted.
- 13 conversion events via `data-cta`, one per engagement tier so package-level
  intent is measurable. `contact-form-submit` fires on delivery, not on click,
  so a failed submit is never counted as a lead.

**Copy and CRO**
- Hero and closing CTA rewritten; the booking action is now the primary button
  (it was the ghost/secondary one).
- FAQ 5 → 8, adding cost, time zones, and exit terms — all previously unanswered.
- Industries leads with Logistics & fleet, evidenced by 5 of the 15 case studies.
- Case studies now link by shared industry rather than array position, which
  clusters the five trucking builds that previously had no path between them.
- Contact form success state links to Calendly (it was plain text); booking card
  precedes the form on mobile; case studies carry a CTA after the results.

## Review notes

Three claims now on the site came from our own FAQ but are front-and-centre for
the first time, and are worth a deliberate yes:

- "Production v1 in 8–12 weeks" — now in the hero and in the structured data
- "You own every line of code we write" — now above the fold
- "Internal tools" was removed from Industries to make room for Logistics; no
  case study evidenced it. If we do sell that work, it should go back.

Two numbers the site asserts could not be verified from the repo: **21+ products
shipped** (auditable count is 15 case studies) and **27 five-star reviews** (real,
but on Upwork/Fiverr, off-site and unlinked). Neither was changed.

## Before merging

The canonical fix changes how the site is indexed. Worth exporting Search Console
performance first — once this deploys, the "before" picture is gone and there's no
way to show the fix worked.

## Verification

- Build compiles clean; 31 static pages generated
- Canonicals confirmed per-page in the built HTML
- JSON-LD confirmed in the served markup on home, services and case-study pages
- All 8 routes return 200 locally
- No `className`, `style`, or JSX structure touched by the copy pass; arrays
  backing repeated UI are unchanged (Industries 6, Capabilities 3, Engagement 3,
  AiNative 12, Process 5, Principles 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
